### PR TITLE
Fix dependency on typesbcp47

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "dependencies": {
         "mtengines": "^1.4.0",
         "typesxml": "^1.3.1",
-        "typesbcp47": "^1.3.2"
+        "typesbcp47": "~1.3.2"
     }
 }


### PR DESCRIPTION
typesbcp47 v1.4.0 is API-breaking and is resolved due to an incorrect semver string in package.json.