### PR TITLE
Add Ollama as a machine translation provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "5.22.0",
             "license": "EPL-1.0",
             "dependencies": {
-                "mtengines": "^4.12.0",
+                "mtengines": "^4.13.0",
                 "sdltm": "^2.4.0",
                 "typesbcp47": "^1.23.0",
                 "typesxml": "^2.1.0"
@@ -248,14 +248,14 @@
             "license": "MIT"
         },
         "node_modules/mtengines": {
-            "version": "4.12.0",
-            "resolved": "https://registry.npmjs.org/mtengines/-/mtengines-4.12.0.tgz",
-            "integrity": "sha512-kO7/xBs+r6kF4gpM7ilfMQlShOjIVZ2GGK6mMEwYMhnzmVetbng8G9dWnVaBiei3IG4FSA0M8LvRJE8UCmokSQ==",
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/mtengines/-/mtengines-4.13.0.tgz",
+            "integrity": "sha512-ft2FLH6/0xTiCVPUgd65+WRuxGysE9A+jkUZXXu9dGGj8ZoiZJnE0CuVOyte7BKq7QD1XdJ3U4ehnne6X7s7Yg==",
             "license": "EPL-1.0",
             "dependencies": {
                 "@anthropic-ai/sdk": "^0.97.1",
-                "typesbcp47": "1.23.0",
-                "typesxml": "2.1.0"
+                "typesbcp47": "1.24.0",
+                "typesxml": "2.2.0"
             },
             "engines": {
                 "node": ">=22"
@@ -351,12 +351,12 @@
             "license": "MIT"
         },
         "node_modules/typesbcp47": {
-            "version": "1.23.0",
-            "resolved": "https://registry.npmjs.org/typesbcp47/-/typesbcp47-1.23.0.tgz",
-            "integrity": "sha512-GLhewtV/UFLIMYS3arg+ndcuuvsXqBt6EqeREJva+w09zZFc94SOS6LgvOJOmHfjhftwcFU+Gfql1ZUsL6j/wQ==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/typesbcp47/-/typesbcp47-1.24.0.tgz",
+            "integrity": "sha512-1mIkqcG3plyxaFuMoZme6TnOrWNVOwDQ24traQ9PghN7bc+QtKYOExRxSrJlsTkTz6pdXaX0cZmSUuSvXp02Lg==",
             "license": "EPL-1.0",
             "dependencies": {
-                "typesxml": "^2.1.0"
+                "typesxml": "^2.2.0"
             }
         },
         "node_modules/typescript": {
@@ -374,9 +374,9 @@
             }
         },
         "node_modules/typesxml": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/typesxml/-/typesxml-2.1.0.tgz",
-            "integrity": "sha512-15spAEtuUs3L8of+5pIRTolqM4VewGdlC8/WDwtksu19p+2ufA+dPW7ApgedRDSAvE12/9Wa2qHGcBYBdXVlOQ==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/typesxml/-/typesxml-2.2.0.tgz",
+            "integrity": "sha512-WF8o0qQ601XBkRmapbYO4Uz/24DPYJYemkke/7lljOpEhCfWocXRg1jY4z1EezdXbOfhS8ikl6fXN/zGVJk9og==",
             "license": "EPL-1.0"
         },
         "node_modules/undici": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "typescript": "^6.0.3"
     },
     "dependencies": {
-        "mtengines": "^4.12.0",
+        "mtengines": "^4.13.0",
         "sdltm": "^2.4.0",
         "typesbcp47": "^1.23.0",
         "typesxml": "^2.1.0"

--- a/ts/Swordfish.ts
+++ b/ts/Swordfish.ts
@@ -162,6 +162,11 @@ export class Swordfish {
             srcLang: 'none',
             tgtLang: 'none'
         },
+        ollama: {
+            enabled: false,
+            url: 'http://localhost:11434',
+            model: ''
+        },
         spellchecker: {
             defaultEnglish: 'en-US',
             defaultPortuguese: 'pt-BR',
@@ -1693,6 +1698,10 @@ export class Swordfish {
                 }
                 if (!json.hasOwnProperty('gemini')) {
                     json.gemini = { enabled: false, apiKey: '', model: 'gemini-2.5-flash', fixTags: false };
+                    needsSaving = true;
+                }
+                if (!json.hasOwnProperty('ollama')) {
+                    json.ollama = { enabled: false, url: 'http://localhost:11434', model: '' };
                     needsSaving = true;
                 }
                 if (!json.hasOwnProperty('appLang')) {

--- a/ts/mtManager.ts
+++ b/ts/mtManager.ts
@@ -10,7 +10,7 @@
  *     Maxprograms - initial API and implementation
  *******************************************************************************/
 
-import { AnthropicTranslator, AzureTranslator, ChatGPTTranslator, DeepLTranslator, GeminiTranslator, GoogleTranslator, MTEngine, MTMatch, MTUtils, MistralTranslator, ModernMTTranslator, QwenTranslator } from "mtengines";
+import { AnthropicTranslator, AzureTranslator, ChatGPTTranslator, DeepLTranslator, GeminiTranslator, GoogleTranslator, MTEngine, MTMatch, MTUtils, MistralTranslator, ModernMTTranslator, OllamaTranslator, QwenTranslator } from "mtengines";
 import { Language, LanguageUtils } from "typesbcp47";
 import { SAXParser, XMLElement } from "typesxml";
 import { MTContentHandler } from "./mtContentHandler.js";
@@ -205,6 +205,12 @@ export class MTManager {
             if (preferences.qwen.fixTags) {
                 this.tagFixer = qwenTranslator;
             }
+        }
+        if (preferences.ollama.enabled) {
+            let ollamaTranslator: OllamaTranslator = new OllamaTranslator(preferences.ollama.url, preferences.ollama.model);
+            ollamaTranslator.setSourceLanguage(srcLang);
+            ollamaTranslator.setTargetLanguage(tgtLang);
+            this.mtEngines.push(ollamaTranslator);
         }
     }
 

--- a/ts/preferences.ts
+++ b/ts/preferences.ts
@@ -85,6 +85,11 @@ export interface Preferences {
         model: string;
         fixTags: boolean;
     };
+    ollama: {
+        enabled: boolean;
+        url: string;
+        model: string;
+    };
     spellchecker: {
         defaultEnglish: string;
         defaultPortuguese: string;

--- a/ts/preferencesDialog.ts
+++ b/ts/preferencesDialog.ts
@@ -88,6 +88,10 @@ export class PreferencesDialog {
     qwenModel: HTMLInputElement = document.createElement('input');
     qwenFixTags: HTMLInputElement = document.createElement('input');
 
+    enableOllama: HTMLInputElement = document.createElement('input');
+    ollamaUrl: HTMLInputElement = document.createElement('input');
+    ollamaModel: HTMLInputElement = document.createElement('input');
+
     defaultEnglish: HTMLSelectElement = document.createElement('select');
     defaultPortuguese: HTMLSelectElement = document.createElement('select');
     defaultSpanish: HTMLSelectElement = document.createElement('select');
@@ -355,6 +359,16 @@ export class PreferencesDialog {
             this.qwenFixTags.disabled = !this.enableQwen.checked;
         });
 
+        this.enableOllama.checked = preferences.ollama.enabled;
+        this.ollamaUrl.value = preferences.ollama.url;
+        this.ollamaModel.value = preferences.ollama.model;
+        this.ollamaUrl.disabled = !preferences.ollama.enabled;
+        this.ollamaModel.disabled = !preferences.ollama.enabled;
+        this.enableOllama.addEventListener('change', () => {
+            this.ollamaUrl.disabled = !this.enableOllama.checked;
+            this.ollamaModel.disabled = !this.enableOllama.checked;
+        });
+
         this.enableModernmt.checked = preferences.modernmt.enabled;
         this.modernmtKey.value = preferences.modernmt.apiKey;
         this.modernmtSrcLang.value = preferences.modernmt.srcLang;
@@ -428,6 +442,14 @@ export class PreferencesDialog {
         }
         if (this.enableQwen.checked && this.qwenModel.value === '') {
             ipcRenderer.send('show-message', { type: 'warning', message: 'Enter Qwen model', parent: 'preferences' });
+            return;
+        }
+        if (this.enableOllama.checked && this.ollamaUrl.value.trim() === '') {
+            ipcRenderer.send('show-message', { type: 'warning', message: 'Enter Ollama server URL', parent: 'preferences' });
+            return;
+        }
+        if (this.enableOllama.checked && this.ollamaModel.value.trim() === '') {
+            ipcRenderer.send('show-message', { type: 'warning', message: 'Enter Ollama model', parent: 'preferences' });
             return;
         }
         if (this.enableMistral.checked && this.mistralKey.value === '') {
@@ -536,6 +558,11 @@ export class PreferencesDialog {
                 apiKey: this.modernmtKey.value,
                 srcLang: this.modernmtSrcLang.value,
                 tgtLang: this.modernmtTgtLang.value
+            },
+            ollama: {
+                enabled: this.enableOllama.checked,
+                url: this.ollamaUrl.value,
+                model: this.ollamaModel.value
             },
             spellchecker: {
                 defaultEnglish: 'en-US',
@@ -1404,6 +1431,24 @@ export class PreferencesDialog {
         modernmtLabel.style.marginTop = '4px';
         radioRow.appendChild(modernmtLabel);
 
+        radioRow = document.createElement('div');
+        radioRow.classList.add('row');
+        radioRow.classList.add('middle');
+        leftSide.appendChild(radioRow);
+
+        let ollamaRadio: HTMLInputElement = document.createElement('input');
+        ollamaRadio.type = 'radio';
+        ollamaRadio.name = 'mtProvider';
+        ollamaRadio.id = 'ollamaRadio';
+        ollamaRadio.style.margin = '4px';
+        radioRow.appendChild(ollamaRadio);
+
+        let ollamaLabel: HTMLLabelElement = document.createElement('label');
+        ollamaLabel.setAttribute('for', 'ollamaRadio');
+        ollamaLabel.innerText = 'Ollama';
+        ollamaLabel.style.marginTop = '4px';
+        radioRow.appendChild(ollamaLabel);
+
         let rightSide: HTMLDivElement = document.createElement('div');
         rightSide.classList.add('fill_width');
         rightSide.style.marginRight = '16px';
@@ -1464,6 +1509,12 @@ export class PreferencesDialog {
         rightSide.appendChild(modernmtTab);
         this.populateModernmtTab(modernmtTab);
 
+        let ollamaTab: HTMLDivElement = document.createElement('div');
+        ollamaTab.id = 'ollamaTab';
+        ollamaTab.style.display = 'none';
+        rightSide.appendChild(ollamaTab);
+        this.populateOllamaTab(ollamaTab);
+
         googleRadio.addEventListener('change', () => {
             console.log('show google tab');
             this.toggleTab('googleTab');
@@ -1500,11 +1551,15 @@ export class PreferencesDialog {
             console.log('show modernmt tab');
             this.toggleTab('modernmtTab');
         });
+        ollamaRadio.addEventListener('change', () => {
+            console.log('show ollama tab');
+            this.toggleTab('ollamaTab');
+        });
     }
 
     toggleTab(tabId: string): void {
         const tabs: string[] = ['googleTab', 'azureTab', 'deeplTab',
-            'chatGptTab', 'mistralTab', 'qwenTab', 'anthropicTab', 'geminiTab', 'modernmtTab'];
+            'chatGptTab', 'mistralTab', 'qwenTab', 'anthropicTab', 'geminiTab', 'modernmtTab', 'ollamaTab'];
         tabs.forEach((id) => {
             const tab = document.getElementById(id);
             if (tab) {
@@ -2186,6 +2241,50 @@ export class PreferencesDialog {
         this.modernmtKey = document.getElementById('modernmtKey') as HTMLInputElement;
         this.modernmtSrcLang = document.getElementById('modernmtSrcLang') as HTMLSelectElement;
         this.modernmtTgtLang = document.getElementById('modernmtTgtLang') as HTMLSelectElement;
+    }
+
+    populateOllamaTab(container: HTMLDivElement): void {
+        container.style.paddingTop = '10px';
+        let ollamaDiv: HTMLDivElement = document.createElement('div');
+        ollamaDiv.classList.add('middle');
+        ollamaDiv.classList.add('row');
+        ollamaDiv.style.paddingLeft = '4px';
+        ollamaDiv.innerHTML = '<input type="checkbox" id="enableOllama"><label for="enableOllama" style="padding-top:4px;">Enable Ollama Translation</label>';
+        container.appendChild(ollamaDiv);
+
+        let langsTable: HTMLTableElement = document.createElement('table');
+        langsTable.classList.add('fill_width');
+        container.appendChild(langsTable);
+
+        let tr: HTMLTableRowElement = document.createElement('tr');
+        langsTable.appendChild(tr);
+        let td: HTMLTableCellElement = document.createElement('td');
+        td.classList.add('middle');
+        td.classList.add('noWrap');
+        td.innerHTML = '<label for="ollamaUrl">Server URL</label>';
+        tr.appendChild(td);
+        td = document.createElement('td');
+        td.classList.add('middle');
+        td.classList.add('fill_width');
+        td.innerHTML = '<input type="text" id="ollamaUrl" class="table_input"/>';
+        tr.appendChild(td);
+
+        tr = document.createElement('tr');
+        langsTable.appendChild(tr);
+        td = document.createElement('td');
+        td.classList.add('middle');
+        td.classList.add('noWrap');
+        td.innerHTML = '<label for="ollamaModel">Model</label>';
+        tr.appendChild(td);
+        td = document.createElement('td');
+        td.classList.add('middle');
+        td.classList.add('fill_width');
+        td.innerHTML = '<input type="text" id="ollamaModel" class="table_input"/>';
+        tr.appendChild(td);
+
+        this.enableOllama = document.getElementById('enableOllama') as HTMLInputElement;
+        this.ollamaUrl = document.getElementById('ollamaUrl') as HTMLInputElement;
+        this.ollamaModel = document.getElementById('ollamaModel') as HTMLInputElement;
     }
 
     requestModelSuggestions(): void {


### PR DESCRIPTION
### What

Wires the `OllamaTranslator` from `mtengines` into Swordfish as a selectable MT/AI provider, so translators can use **local models served by Ollama** — or any Ollama `/api/chat`-compatible endpoint — for AI translation, alongside the existing providers (ChatGPT, Claude, Gemini, Mistral, Qwen, …).

### Why

`mtengines` already ships `OllamaTranslator` (since 4.13.0), but Swordfish doesn't surface it, so there's no way to configure a local Ollama model from the UI. Local models are attractive for privacy/offline/cost-sensitive workflows (no source text leaves the machine). Unlike the hosted providers, `OllamaTranslator` takes a configurable base URL, so it also enables pointing Swordfish at any Ollama-compatible endpoint.

### Changes

- **`preferences.ts`** — add `ollama: { enabled, url, model }` to `Preferences`.
- **`Swordfish.ts`** — default preference (`url` defaults to `http://localhost:11434`) and a migration entry so existing preference files gain the `ollama` key.
- **`mtManager.ts`** — construct `OllamaTranslator(url, model)` when enabled. No tag-fixing is wired, since the mtengines Ollama engine doesn't implement `fixMatch`/`fixTags`.
- **`preferencesDialog.ts`** — add the **Ollama** radio + a preferences tab (Server URL + Model), with load / save / validation, mirroring the existing provider tabs (closest analog: the Claude/Anthropic tab).
- **`package.json`** — bump `mtengines` to `^4.13.0` (the version that exports `OllamaTranslator`).

### Testing

- `npm run build` (tsc) compiles cleanly with the change (`mtengines@4.13.0`).
- **Caveat:** I could not run the Electron UI in my environment, so I haven't visually verified the new preferences tab renders/saves correctly — it mirrors the existing Claude tab, but a quick visual check would be appreciated.

Happy to adjust naming, layout, or add a `think` toggle / model suggestions if you'd like it to match the other AI tabs more closely.

---
*Contributed under EPL-1.0; signed off via DCO.*